### PR TITLE
feat: make base url for webservice calls dynamic

### DIFF
--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -1,5 +1,8 @@
-function getData(url) {
-    return fetch(url, {
+function getData(url, apiAddress) {
+    // remove trailing slash from apiAddress if present
+    apiAddress = apiAddress.endsWith('/') ? apiAddress.slice(0, -1) : apiAddress;
+
+    return fetch(`${apiAddress}${url}`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -19,58 +22,70 @@ function getData(url) {
         });
 }
 
-export function getOriginInfo(originid) {
-    return getData(`${process.env.API_ADDRESS}/v1/origin/${originid}`);
+export function getOriginInfo(originid, apiAddress = process.env.API_ADDRESS) {
+    return getData(`/v1/origin/${originid}`, apiAddress);
 }
 
-export function getDangerLevel(originid) {
-    return getData(`${process.env.API_ADDRESS}/v1/origin/${originid}/dangerlevel`);
+export function getDangerLevel(originid, apiAddress = process.env.API_ADDRESS) {
+    return getData(`/v1/origin/${originid}/dangerlevel`, apiAddress);
 }
 
-export function getOriginDescription(originid, lang) {
-    return getData(`${process.env.API_ADDRESS}/v1/origin/${originid}/description/${lang}`);
+export function getOriginDescription(originid, lang, apiAddress = process.env.API_ADDRESS) {
+    return getData(`/v1/origin/${originid}/description/${lang}`, apiAddress);
 }
 
-export function getRiskAssessment(oid) {
-    return getData(`${process.env.API_ADDRESS}/v1/riskassessment/${oid}`);
+export function getRiskAssessment(oid, apiAddress = process.env.API_ADDRESS) {
+    return getData(`/v1/riskassessment/${oid}`, apiAddress);
 }
 
-export function getAllRiskAssessments(limit = 20, offset = 0) {
-    return getData(`${process.env.API_ADDRESS}/v1/riskassessment?limit=${limit}&offset=${offset}`);
+export function getAllRiskAssessments(
+    limit = 20,
+    offset = 0,
+    apiAddress = process.env.API_ADDRESS
+) {
+    return getData(`/v1/riskassessment?limit=${limit}&offset=${offset}`, apiAddress);
 }
 
-export function getCasualties(oid, aggregation, tag = null, sum = false) {
-    let base = `${process.env.API_ADDRESS}/v1/loss/${oid}/fatalities`;
-    if (sum) if (tag === 'CH') return getData(`${base}/Country`);
-    return getData(`${base}/Canton?filter_tag_like=${tag}`);
+export function getLoss(
+    oid,
+    type,
+    aggregation,
+    tag = null,
+    sum = false,
+    apiAddress = process.env.API_ADDRESS
+) {
+    let base = `/v1/loss/${oid}/${type}/${aggregation}`;
+    if (sum) return getData(`${base}?sum=true`, apiAddress);
+    if (tag) return getData(`${base}?filter_tag_like=${tag}`, apiAddress);
+    return getData(base, apiAddress);
 }
 
-export function getLoss(oid, type, aggregation, tag = null, sum = false) {
-    let base = `${process.env.API_ADDRESS}/v1/loss/${oid}/${type}/${aggregation}`;
-    if (sum) return getData(`${base}?sum=true`);
-    if (tag) return getData(`${base}?filter_tag_like=${tag}`);
-    return getData(base);
+export function getDamage(
+    oid,
+    type,
+    aggregation,
+    tag = null,
+    sum = false,
+    apiAddress = process.env.API_ADDRESS
+) {
+    let base = `/v1/damage/${oid}/${type}/${aggregation}/report`;
+    if (sum) return getData(`${base}?sum=true`, apiAddress);
+    if (tag) return getData(`${base}?filter_tag_like=${tag}`, apiAddress);
+    return getData(base, apiAddress);
 }
 
-export function getDamage(oid, type, aggregation, tag = null, sum = false) {
-    let base = `${process.env.API_ADDRESS}/v1/damage/${oid}/${type}/${aggregation}/report`;
-    if (sum) return getData(`${base}?sum=true`);
-    if (tag) return getData(`${base}?filter_tag_like=${tag}`);
-    return getData(base);
-}
-
-export function getCantonalInjuries(oid) {
-    let cantonal = getLoss(oid, 'injured', 'Canton');
-    let country = getLoss(oid, 'injured', 'Canton', null, true);
+export function getCantonalInjuries(oid, apiAddress = process.env.API_ADDRESS) {
+    let cantonal = getLoss(oid, 'injured', 'Canton', null, false, apiAddress);
+    let country = getLoss(oid, 'injured', 'Canton', null, true, apiAddress);
     return Promise.all([cantonal, country]).then(([ca, co]) => {
         co.forEach((c) => (c.tag = ['CH']));
         return ca.concat(co);
     });
 }
 
-export function getCantonalStructuralDamage(oid) {
-    let cantonal = getDamage(oid, 'structural', 'Canton');
-    let country = getDamage(oid, 'structural', 'Canton', null, true);
+export function getCantonalStructuralDamage(oid, apiAddress = process.env.API_ADDRESS) {
+    let cantonal = getDamage(oid, 'structural', 'Canton', null, false, apiAddress);
+    let country = getDamage(oid, 'structural', 'Canton', null, true, apiAddress);
     return Promise.all([cantonal, country]).then(([ca, co]) => {
         co.forEach((c) => (c.tag = ['CH']));
         return ca.concat(co);

--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -1,4 +1,5 @@
 function getData(url, apiAddress) {
+    apiAddress = apiAddress || process.env.API_ADDRESS;
     // remove trailing slash from apiAddress if present
     apiAddress = apiAddress.endsWith('/') ? apiAddress.slice(0, -1) : apiAddress;
 
@@ -22,59 +23,41 @@ function getData(url, apiAddress) {
         });
 }
 
-export function getOriginInfo(originid, apiAddress = process.env.API_ADDRESS) {
+export function getOriginInfo(originid, apiAddress = null) {
     return getData(`/v1/origin/${originid}`, apiAddress);
 }
 
-export function getDangerLevel(originid, apiAddress = process.env.API_ADDRESS) {
+export function getDangerLevel(originid, apiAddress = null) {
     return getData(`/v1/origin/${originid}/dangerlevel`, apiAddress);
 }
 
-export function getOriginDescription(originid, lang, apiAddress = process.env.API_ADDRESS) {
+export function getOriginDescription(originid, lang, apiAddress = null) {
     return getData(`/v1/origin/${originid}/description/${lang}`, apiAddress);
 }
 
-export function getRiskAssessment(oid, apiAddress = process.env.API_ADDRESS) {
+export function getRiskAssessment(oid, apiAddress = null) {
     return getData(`/v1/riskassessment/${oid}`, apiAddress);
 }
 
-export function getAllRiskAssessments(
-    limit = 20,
-    offset = 0,
-    apiAddress = process.env.API_ADDRESS
-) {
+export function getAllRiskAssessments(limit = 20, offset = 0, apiAddress = null) {
     return getData(`/v1/riskassessment?limit=${limit}&offset=${offset}`, apiAddress);
 }
 
-export function getLoss(
-    oid,
-    type,
-    aggregation,
-    tag = null,
-    sum = false,
-    apiAddress = process.env.API_ADDRESS
-) {
+export function getLoss(oid, type, aggregation, tag = null, sum = false, apiAddress = null) {
     let base = `/v1/loss/${oid}/${type}/${aggregation}`;
     if (sum) return getData(`${base}?sum=true`, apiAddress);
     if (tag) return getData(`${base}?filter_tag_like=${tag}`, apiAddress);
     return getData(base, apiAddress);
 }
 
-export function getDamage(
-    oid,
-    type,
-    aggregation,
-    tag = null,
-    sum = false,
-    apiAddress = process.env.API_ADDRESS
-) {
+export function getDamage(oid, type, aggregation, tag = null, sum = false, apiAddress = null) {
     let base = `/v1/damage/${oid}/${type}/${aggregation}/report`;
     if (sum) return getData(`${base}?sum=true`, apiAddress);
     if (tag) return getData(`${base}?filter_tag_like=${tag}`, apiAddress);
     return getData(base, apiAddress);
 }
 
-export function getCantonalInjuries(oid, apiAddress = process.env.API_ADDRESS) {
+export function getCantonalInjuries(oid, apiAddress = null) {
     let cantonal = getLoss(oid, 'injured', 'Canton', null, false, apiAddress);
     let country = getLoss(oid, 'injured', 'Canton', null, true, apiAddress);
     return Promise.all([cantonal, country]).then(([ca, co]) => {
@@ -83,7 +66,7 @@ export function getCantonalInjuries(oid, apiAddress = process.env.API_ADDRESS) {
     });
 }
 
-export function getCantonalStructuralDamage(oid, apiAddress = process.env.API_ADDRESS) {
+export function getCantonalStructuralDamage(oid, apiAddress = null) {
     let cantonal = getDamage(oid, 'structural', 'Canton', null, false, apiAddress);
     let country = getDamage(oid, 'structural', 'Canton', null, true, apiAddress);
     return Promise.all([cantonal, country]).then(([ca, co]) => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -118,7 +118,7 @@ module.exports = (env) => ({
         },
         watchFiles: ['src/**/*'],
         open: false,
-        hot: false,
+        hot: true,
         host: 'localhost',
         port: 5000,
     },


### PR DESCRIPTION
Passing the api address through to the base function so that it is possible to check (can be expanded on if necessary) the correct form or even use an external package like path-browserify.