### PR TITLE
feat: utc to local time

### DIFF
--- a/src/data/lang/de-report.json
+++ b/src/data/lang/de-report.json
@@ -10,7 +10,7 @@
   "keine_f": "keine",
   "ueberblick": "Überblick",
   "ueberblick-stufe": "Gefahrenstufe",
-  "ueberblick-zeit": "Zeit [CET]",
+  "ueberblick-zeit": "Lokalzeit",
   "ueberblick-datum": "Datum",
   "ueberblick-tiefe": "Herdtiefe",
   "ueberblick-auswertung": "Auswertung",

--- a/src/data/lang/de-report.json
+++ b/src/data/lang/de-report.json
@@ -10,7 +10,7 @@
   "keine_f": "keine",
   "ueberblick": "Überblick",
   "ueberblick-stufe": "Gefahrenstufe",
-  "ueberblick-zeit": "Zeit [UTC]",
+  "ueberblick-zeit": "Zeit [CET]",
   "ueberblick-datum": "Datum",
   "ueberblick-tiefe": "Herdtiefe",
   "ueberblick-auswertung": "Auswertung",

--- a/src/data/lang/en-report.json
+++ b/src/data/lang/en-report.json
@@ -11,7 +11,7 @@
     "automatisch": "automatisch",
     "ueberblick": "Overview",
     "ueberblick-stufe": "Danger level",
-    "ueberblick-zeit": "Time [UTC]",
+    "ueberblick-zeit": "Time [CET]",
     "ueberblick-datum": "Date",
     "ueberblick-tiefe": "Hypocentral depth",
     "ueberblick-auswertung": "Assessment",

--- a/src/data/lang/en-report.json
+++ b/src/data/lang/en-report.json
@@ -11,7 +11,7 @@
     "automatisch": "automatisch",
     "ueberblick": "Overview",
     "ueberblick-stufe": "Danger level",
-    "ueberblick-zeit": "Time [CET]",
+    "ueberblick-zeit": "Local time",
     "ueberblick-datum": "Date",
     "ueberblick-tiefe": "Hypocentral depth",
     "ueberblick-auswertung": "Assessment",

--- a/src/data/lang/fr-report.json
+++ b/src/data/lang/fr-report.json
@@ -10,7 +10,7 @@
   "keine_f": "aucune",
   "ueberblick": "Aperçu",
   "ueberblick-stufe": "Degré de danger",
-  "ueberblick-zeit": "Heure [UTC]",
+  "ueberblick-zeit": "Heure [CET]",
   "ueberblick-datum": "Date",
   "ueberblick-tiefe": "Profondeur du foyer",
   "ueberblick-auswertung": "Évaluation",

--- a/src/data/lang/fr-report.json
+++ b/src/data/lang/fr-report.json
@@ -10,7 +10,7 @@
   "keine_f": "aucune",
   "ueberblick": "Aperçu",
   "ueberblick-stufe": "Degré de danger",
-  "ueberblick-zeit": "Heure [CET]",
+  "ueberblick-zeit": "Heure locale",
   "ueberblick-datum": "Date",
   "ueberblick-tiefe": "Profondeur du foyer",
   "ueberblick-auswertung": "Évaluation",

--- a/src/data/lang/it-report.json
+++ b/src/data/lang/it-report.json
@@ -10,7 +10,7 @@
     "keine_f": "nessuno",
     "ueberblick": "Riepilogo",
     "ueberblick-stufe": "Livello di pericolo",
-    "ueberblick-zeit": "Ora [UTC]",
+    "ueberblick-zeit": "Ora [CET]",
     "ueberblick-datum": "Data",
     "ueberblick-tiefe": "Profondità dell’ipocentro",
     "ueberblick-auswertung": "Analisi",

--- a/src/data/lang/it-report.json
+++ b/src/data/lang/it-report.json
@@ -10,7 +10,7 @@
     "keine_f": "nessuno",
     "ueberblick": "Riepilogo",
     "ueberblick-stufe": "Livello di pericolo",
-    "ueberblick-zeit": "Ora [CET]",
+    "ueberblick-zeit": "Ora locale",
     "ueberblick-datum": "Data",
     "ueberblick-tiefe": "Profondità dell’ipocentro",
     "ueberblick-auswertung": "Analisi",

--- a/src/js/components/DataComponent.js
+++ b/src/js/components/DataComponent.js
@@ -9,9 +9,9 @@ import {
     getOriginDescription,
 } from '../utils/api';
 import {
-    parseUTCDate,
+    parseDate,
     formatDate,
-    formatUTCTime,
+    formatTime,
     b64encode,
     round,
     loadImage,
@@ -178,9 +178,8 @@ class DataComponent {
         }
 
         headerBox.forEach((box) => box.classList.add('natural'));
-
-        let date = parseUTCDate(info?.creationinfo?.creationtime);
-        headerDatetime.innerHTML = date ? `${formatDate(date)}, ${formatUTCTime(date)} UTC` : '';
+        let date = parseDate(info?.creationinfo?.creationtime, 'CET');
+        headerDatetime.innerHTML = date ? `${formatDate(date)}, ${formatTime(date)} CET` : '';
     }
 
     addOriginDescription(originId) {

--- a/src/js/components/DataComponent.js
+++ b/src/js/components/DataComponent.js
@@ -9,7 +9,7 @@ import {
     getOriginDescription,
 } from '../utils/api';
 import {
-    parseDate,
+    parseUTCDate,
     formatDate,
     formatTime,
     b64encode,
@@ -178,7 +178,7 @@ class DataComponent {
         }
 
         headerBox.forEach((box) => box.classList.add('natural'));
-        let date = parseDate(info?.creationinfo?.creationtime, 'Europe/Zurich');
+        let date = parseUTCDate(info?.creationinfo?.creationtime, 'Europe/Zurich');
         headerDatetime.innerHTML = date ? `${formatDate(date)}, ${formatTime(date)} CET` : '';
     }
 

--- a/src/js/components/DataComponent.js
+++ b/src/js/components/DataComponent.js
@@ -178,7 +178,7 @@ class DataComponent {
         }
 
         headerBox.forEach((box) => box.classList.add('natural'));
-        let date = parseDate(info?.creationinfo?.creationtime, 'CET');
+        let date = parseDate(info?.creationinfo?.creationtime, 'Europe/Zurich');
         headerDatetime.innerHTML = date ? `${formatDate(date)}, ${formatTime(date)} CET` : '';
     }
 

--- a/src/js/utils/utilities.js
+++ b/src/js/utils/utilities.js
@@ -65,7 +65,7 @@ export function clamp(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
 
-export function parseDate(dateString, targetTimeZone = 'Europe/Zurich') {
+export function parseUTCDate(dateString, targetTimeZone = 'Europe/Zurich') {
     // Parse a date string and set timezone
     // depending on targetTimeZone.
     // If there is no timezone information in the dateString,

--- a/src/js/utils/utilities.js
+++ b/src/js/utils/utilities.js
@@ -65,8 +65,10 @@ export function clamp(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
 
-export function parseUTCDate(dateString) {
-    // Parse a date string. If there is no timezone information,
+export function parseDate(dateString, targetTimeZone = 'CET') {
+    // Parse a date string and set timezone
+    // depending on targetTimeZone.
+    // If there is no timezone information in the dateString,
     // assume UTC
 
     if (typeof dateString !== 'string') return null;
@@ -76,25 +78,25 @@ export function parseUTCDate(dateString) {
     if (Number.isNaN(ts)) {
         ts = Date.parse(dateString);
     }
+
     let date = new Date(ts);
-    return date;
+    let supportedTimeZone = Intl.supportedValuesOf('timeZone').includes(targetTimeZone);
+
+    let timeZoneDate = supportedTimeZone
+        ? new Date(date.toLocaleString('en-US', { targetTimeZone }))
+        : new Date(date.toLocaleString('en-US', { timeZone: 'CET' }));
+    return timeZoneDate;
 }
 
 export function formatDate(date) {
-    // Format a date as DD.MM.YYYY
-
     return `${String(date.getDate()).padStart(2, 0)}.${String(date.getMonth() + 1).padStart(
         2,
         0
     )}.${date.getFullYear()}`;
 }
 
-export function formatUTCTime(date) {
-    // Format a date time as HH:MM
-    return `${String(date.getUTCHours()).padStart(2, 0)}:${String(date.getMinutes()).padStart(
-        2,
-        0
-    )}`;
+export function formatTime(date) {
+    return `${String(date.getHours()).padStart(2, 0)}:${String(date.getMinutes()).padStart(2, 0)}`;
 }
 
 export async function injectSVG(path, element) {

--- a/src/js/utils/utilities.js
+++ b/src/js/utils/utilities.js
@@ -65,7 +65,7 @@ export function clamp(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
 
-export function parseDate(dateString, targetTimeZone = 'CET') {
+export function parseDate(dateString, targetTimeZone = 'Europe/Zurich') {
     // Parse a date string and set timezone
     // depending on targetTimeZone.
     // If there is no timezone information in the dateString,
@@ -83,8 +83,8 @@ export function parseDate(dateString, targetTimeZone = 'CET') {
     let supportedTimeZone = Intl.supportedValuesOf('timeZone').includes(targetTimeZone);
 
     let timeZoneDate = supportedTimeZone
-        ? new Date(date.toLocaleString('en-US', { targetTimeZone }))
-        : new Date(date.toLocaleString('en-US', { timeZone: 'CET' }));
+        ? new Date(date.toLocaleString('en-US', { timeZone: targetTimeZone }))
+        : new Date(date.toLocaleString('en-US', { timeZone: 'Europe/Zurich' }));
     return timeZoneDate;
 }
 

--- a/src/js/utils/utilities.js
+++ b/src/js/utils/utilities.js
@@ -89,6 +89,8 @@ export function parseUTCDate(dateString, targetTimeZone = 'Europe/Zurich') {
 }
 
 export function formatDate(date) {
+    // Format a date as DD.MM.YYYY
+
     return `${String(date.getDate()).padStart(2, 0)}.${String(date.getMonth() + 1).padStart(
         2,
         0
@@ -96,6 +98,7 @@ export function formatDate(date) {
 }
 
 export function formatTime(date) {
+    // Format a date time as HH:MM
     return `${String(date.getHours()).padStart(2, 0)}:${String(date.getMinutes()).padStart(2, 0)}`;
 }
 

--- a/src/js/webcomponents/InfoTable.js
+++ b/src/js/webcomponents/InfoTable.js
@@ -4,9 +4,9 @@ import i18next from 'i18next';
 
 import {
     round,
-    parseUTCDate,
+    parseDate,
     formatDate,
-    formatUTCTime,
+    formatTime,
     b64encode,
     thousandsFormatter,
 } from '../utils/utilities';
@@ -66,9 +66,11 @@ class InfoTable extends HTMLElement {
             this.origininfo.latitude = round(this.origininfo.latitude, 0);
         } catch (e) {} // eslint-disable-line
 
-        this.origininfo.time = this.origininfo?.time ? parseUTCDate(this.origininfo.time) : null;
+        this.origininfo.time = this.origininfo?.time
+            ? parseDate(this.origininfo.time, 'CET')
+            : null;
         this.origininfo.date = this.origininfo.time ? formatDate(this.origininfo.time) : null;
-        this.origininfo.time = this.origininfo.time ? formatUTCTime(this.origininfo.time) : null;
+        this.origininfo.time = this.origininfo.time ? formatTime(this.origininfo.time) : null;
 
         // prettier-ignore
         this.origininfo.href = `${process.env.SED_HOMEPAGE}/${i18next.language}/earthquakes/switzerland/eventpage.html?originId=%27${b64encode(this.originid)}%27`; // eslint-disable-line

--- a/src/js/webcomponents/InfoTable.js
+++ b/src/js/webcomponents/InfoTable.js
@@ -4,7 +4,7 @@ import i18next from 'i18next';
 
 import {
     round,
-    parseDate,
+    parseUTCDate,
     formatDate,
     formatTime,
     b64encode,
@@ -67,7 +67,7 @@ class InfoTable extends HTMLElement {
         } catch (e) {} // eslint-disable-line
 
         this.origininfo.time = this.origininfo?.time
-            ? parseDate(this.origininfo.time, 'Europe/Zurich')
+            ? parseUTCDate(this.origininfo.time, 'Europe/Zurich')
             : null;
         this.origininfo.date = this.origininfo.time ? formatDate(this.origininfo.time) : null;
         this.origininfo.time = this.origininfo.time ? formatTime(this.origininfo.time) : null;

--- a/src/js/webcomponents/InfoTable.js
+++ b/src/js/webcomponents/InfoTable.js
@@ -67,7 +67,7 @@ class InfoTable extends HTMLElement {
         } catch (e) {} // eslint-disable-line
 
         this.origininfo.time = this.origininfo?.time
-            ? parseDate(this.origininfo.time, 'CET')
+            ? parseDate(this.origininfo.time, 'Europe/Zurich')
             : null;
         this.origininfo.date = this.origininfo.time ? formatDate(this.origininfo.time) : null;
         this.origininfo.time = this.origininfo.time ? formatTime(this.origininfo.time) : null;


### PR DESCRIPTION
* Generic `parseDate` (with target timezone as optional argument) and `formatDate`. `parseDate` still operates under the assumption of UTC as the input timezone.
* Using Europe/Zurich as default target time zone. Chrome and Safari do not recognize timezones 'UTC' and 'CET' (https://github.com/tc39/ecma402/issues/778). For UTC, we should use Europe/London I guess 