### PR TITLE
Update removed report endpoint

### DIFF
--- a/src/js/components/DataComponent.js
+++ b/src/js/components/DataComponent.js
@@ -136,15 +136,17 @@ class DataComponent {
                 infoTable.setAttribute('originInfo', JSON.stringify(originInfo));
 
                 overviewMagnitude.innerHTML = `${round(originInfo.magnitude, 1) || '-'} [${
-                    originInfo.magnitudetype || ''
+                    originInfo.magnitudetype || 'ml'
                 }]`;
 
-                let canton = originInfo.region.split(' ').pop();
-                // remove last occurrence of "canton" abbreviation and add it in brackets
-                originInfo.region = `${originInfo.region.replace(
-                    new RegExp(`${canton}$`),
-                    ''
-                )}(${canton})`;
+                if (originInfo.region) {
+                    let canton = originInfo.region?.split(' ').pop();
+                    // remove last occurrence of "canton" abbreviation and add it in brackets
+                    originInfo.region = `${originInfo.region.replace(
+                        new RegExp(`${canton}$`),
+                        ''
+                    )}(${canton})`;
+                }
 
                 headerTitle.innerHTML = i18next.t('preposition_title', {
                     name: originInfo.region || '-',

--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -55,6 +55,19 @@ export function getAllRiskAssessments(limit = 20, offset = 0, originid = null, a
     return getData('/v1/riskassessment', apiAddress, queryParams);
 }
 
+export function getAllRiskAssessmentsForOrigin(
+    originid,
+    limit = 200,
+    offset = 0,
+    apiAddress = null
+) {
+    const queryParams = {
+        limit,
+        offset,
+    };
+    return getData(`/v1/origin/${originid}/riskassessment`, apiAddress, queryParams);
+}
+
 export function getAllRiskAssessmentsWithFlag(limit = 20, offset = 0, apiAddress = null) {
     const [secretKey, secretValue] = process.env.SECRET.split('=');
     const queryParams = {

--- a/src/js/webcomponents/DataLoader.js
+++ b/src/js/webcomponents/DataLoader.js
@@ -1,8 +1,8 @@
 import {
-    getAllRiskAssessments,
     getLoss,
     getCantonalInjuries,
     getCantonalStructuralDamage,
+    getAllRiskAssessmentsForOrigin,
 } from '../utils/api';
 
 class DataLoader extends HTMLElement {
@@ -97,12 +97,13 @@ class DataLoader extends HTMLElement {
 
     async fetchRiskAssessmentData() {
         try {
-            const riskAssessments = await getAllRiskAssessments(
+            const riskAssessments = await getAllRiskAssessmentsForOrigin(
+                this.originid,
                 100,
                 0,
-                this.originid,
                 this.baseurl
             );
+
             const preferred = riskAssessments.items.filter(
                 (item) => item.preferred && item.published
             );


### PR DESCRIPTION
- improve errorhandling
- adapt to change that the /report endpoint is removed, need to calculate sum of damagegrades and percentages on client
- also add change to use the new endpoint which retrieves all the riskassessments for the event to which the origin belongs. This way the dataloader always displays the latest preferred and published RIA for the event, independent if the ria is requested for a newer or older origin.