### PR TITLE
fix: remove italian preposition

### DIFF
--- a/src/js/components/i18nComponent.js
+++ b/src/js/components/i18nComponent.js
@@ -31,13 +31,6 @@ export async function initI18next() {
             }
             return `de ${value}`;
         }
-        if (lng === 'it') {
-            let vocals = ['a', 'e', 'i', 'y', 'o', 'u'];
-            if (vocals.includes(value[0].toLowerCase())) {
-                return `ad ${value}`;
-            }
-            return `a ${value}`;
-        }
         return value;
     });
 }


### PR DESCRIPTION
"Presso a `<Location>`" is not correct. Since the Italian prepositional logic ('a' or 'ad' depending on vowels or consonants) is used only in preposition_title, the logic has been removed. After consultation with the Communication team, it is now "`Presso <Location>`". 