### PR TITLE
feat: change tick/colorscale scales

### DIFF
--- a/src/js/utils/CantonalGraph.js
+++ b/src/js/utils/CantonalGraph.js
@@ -131,14 +131,15 @@ export default function CantonalGraph(
     if (displayValue) {
         // PERCENT BACKDROP
         svg.append('rect')
-            .attr('x', xScale(0) + dataWidth + widthDamage * paddingLeftDamage)
+            .attr('x', xScale(xDomain[0]) + dataWidth + widthDamage * paddingLeftDamage)
             .attr('y', yScale(Y[0]) - innerPadding / 2)
             .attr('width', widthDamage)
             .attr('height', dataHeight - outerPadding / 2)
             .style('fill', '#cbcbcb');
 
         svg.append('rect')
-            .attr('x', xScale(0) + rightColumnStart + dataWidth + widthDamage * paddingLeftDamage)
+            .attr('x', xScale(xDomain[0]) + 
+                        rightColumnStart + dataWidth + widthDamage * paddingLeftDamage)
             .attr('y', yScale(Y[0]) - innerPadding / 2)
             .attr('width', widthDamage)
             .attr('height', dataHeight - yScale.step() - outerPadding / 2)
@@ -168,7 +169,7 @@ export default function CantonalGraph(
                 .attr(
                     'x',
                     (n, i) =>
-                        xScale(0) +
+                        xScale(xDomain[0]) +
                         i * rightColumnStart +
                         dataWidth +
                         widthDamage * paddingLeftDamage +
@@ -190,7 +191,7 @@ export default function CantonalGraph(
             .attr(
                 'x',
                 (i) =>
-                    xScale(0) +
+                    xScale(xDomain[0]) +
                     dataWidth +
                     widthDamage * paddingLeftDamage +
                     widthDamage / 2 +
@@ -219,7 +220,9 @@ export default function CantonalGraph(
                 .append('stop')
                 .attr(
                     'offset',
-                    (i) => (xScale(X[i][0]) - xScale(0)) / (xScale(xDomain[1]) - xScale(0)) || 0
+                (i) => 
+                    (xScale(X[i][0]) - 
+                xScale(xDomain[0])) / (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0');
@@ -229,8 +232,8 @@ export default function CantonalGraph(
                 .attr(
                     'offset',
                     (i) =>
-                        (xScale(X[i][0]) - xScale(0) + 0.7 * range1(i)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                        (xScale(X[i][0]) - xScale(xDomain[0]) + 0.7 * range1(i)) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0.4');
@@ -240,8 +243,8 @@ export default function CantonalGraph(
                 .attr(
                     'offset',
                     (i) =>
-                        (xScale(X[i][0]) - xScale(0) + 0.95 * range1(i)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                        (xScale(X[i][0]) - xScale(xDomain[0]) + 0.95 * range1(i)) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0.85');
@@ -252,8 +255,8 @@ export default function CantonalGraph(
                     'offset',
                     (i) =>
                         (xScale(max([X[i][1], xTickValues[0] + xTickValues[1] * 0.015])) -
-                            xScale(0)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                            xScale(xDomain[0])) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0.98');
@@ -263,8 +266,8 @@ export default function CantonalGraph(
                 .attr(
                     'offset',
                     (i) =>
-                        (xScale(X[i][2]) - xScale(0) - 0.95 * range2(i)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                        (xScale(X[i][2]) -xScale(xDomain[0]) - 0.95 * range2(i)) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0.85');
@@ -274,8 +277,8 @@ export default function CantonalGraph(
                 .attr(
                     'offset',
                     (i) =>
-                        (xScale(X[i][2]) - xScale(0) - 0.7 * range2(i)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                        (xScale(X[i][2]) - xScale(xDomain[0]) - 0.7 * range2(i)) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0.4');
@@ -286,8 +289,8 @@ export default function CantonalGraph(
                     'offset',
                     (i) =>
                         (xScale(max([X[i][2], xTickValues[0] + xTickValues[1] * 0.05])) -
-                            xScale(0)) /
-                            (xScale(xDomain[1]) - xScale(0)) || 0
+                            xScale(xDomain[0])) /
+                            (xScale(xDomain[1]) - xScale(xDomain[0])) || 0
                 )
                 .attr('stop-color', 'white')
                 .attr('stop-opacity', '0');
@@ -299,7 +302,7 @@ export default function CantonalGraph(
         .data(I)
         .join('rect')
         .attr('fill', (i) => (Y[i] === 'CH' ? '#cbcbcb' : '#d3d3d3'))
-        .attr('x', (i) => xScale(0) + getHalf(i) * rightColumnStart)
+        .attr('x', (i) => xScale(xDomain[0]) + getHalf(i) * rightColumnStart)
         .attr('y', (i) => yScale(Y[i - getHalf(i) * half]))
         .attr('width', dataWidth)
         .attr('height', yScale.bandwidth());
@@ -310,14 +313,14 @@ export default function CantonalGraph(
         .selectAll('foo')
         .data(I)
         .join('rect')
-        .attr('x', (i) => xScale(0) + getHalf(i) * rightColumnStart)
+        .attr('x', (i) => xScale(xDomain[0]) + getHalf(i) * rightColumnStart)
         .attr('y', (i) => yScale(Y[i - getHalf(i) * half]))
         .attr('width', dataWidth)
         .attr('height', yScale.bandwidth())
         .attr('fill', (i) => `url(#mask-gradient-${unique}-${Y[i]})`);
 
     svg.append('rect')
-        .attr('x', xScale(0))
+        .attr('x', xScale(xDomain[0]))
         .attr('y', yScale(Y[0]) - outerPadding)
         .attr('width', dataWidth)
         .attr('height', height - yScale(Y[0]) - outerPadding)
@@ -325,7 +328,7 @@ export default function CantonalGraph(
         .attr('mask', `url(#data-mask-${unique})`);
 
     svg.append('rect')
-        .attr('x', xScale(0) + rightColumnStart)
+        .attr('x', xScale(xDomain[0]) + rightColumnStart)
         .attr('y', yScale(Y[0]) - outerPadding)
         .attr('width', dataWidth)
         .attr('height', height - yScale(Y[0]) - outerPadding)

--- a/src/js/utils/ColorScale.js
+++ b/src/js/utils/ColorScale.js
@@ -54,13 +54,22 @@ export function ColorScaleMarker(start, center, end, canvasElement) {
 }
 
 export function getPercentage(value, thresholds) {
+    
+    if (value <= thresholds[0]) {
+        return 0;
+    }
+
+
     let index = thresholds.findIndex((el) => el > value);
     if (index < 0) return 1;
     let [smaller, bigger] = thresholds.slice(index - 1, index + 1);
-    let minLog = Math.log10(Math.max(smaller, 1));
+    let minLog = Math.log10(Math.max(smaller, thresholds[0]));
     let maxLog = Math.log10(bigger);
+
     return (
-        ((Math.log10(clamp(value, 1, bigger)) - minLog) / (maxLog - minLog)) * 0.2 +
+        ((Math.log10(clamp(value, thresholds[0], bigger)) - minLog) / (maxLog - minLog)) * 0.2 +
         (index - 1) * 0.2
     );
 }
+
+

--- a/src/js/utils/ColorScale.js
+++ b/src/js/utils/ColorScale.js
@@ -55,11 +55,6 @@ export function ColorScaleMarker(start, center, end, canvasElement) {
 
 export function getPercentage(value, thresholds) {
     
-    if (value <= thresholds[0]) {
-        return 0;
-    }
-
-
     let index = thresholds.findIndex((el) => el > value);
     if (index < 0) return 1;
     let [smaller, bigger] = thresholds.slice(index - 1, index + 1);

--- a/src/js/webcomponents/DamageGraph.js
+++ b/src/js/webcomponents/DamageGraph.js
@@ -60,9 +60,7 @@ class DamageGraph extends HTMLElement {
             marginLeft: 30,
             marginRight: 20,
             gutter: 40,
-            x: (d) => d.damage_pc90 >= 5 
-                        ? [d.damage_pc10, d.damage_mean, d.damage_pc90, d.damage_percentage]
-                        : [0, 0, 0, 0],
+            x: (d) => [d.damage_pc10, d.damage_mean, d.damage_pc90, d.damage_percentage],
             y: (d) => d.tag[0],
             symlogConstant: 0.1,
             xTickFormat: (d) =>

--- a/src/js/webcomponents/DamageGraph.js
+++ b/src/js/webcomponents/DamageGraph.js
@@ -60,15 +60,17 @@ class DamageGraph extends HTMLElement {
             marginLeft: 30,
             marginRight: 20,
             gutter: 40,
-            x: (d) => [d.damage_pc10, d.damage_mean, d.damage_pc90, d.damage_percentage],
+            x: (d) => d.damage_pc90 >= 5 
+                        ? [d.damage_pc10, d.damage_mean, d.damage_pc90, d.damage_percentage]
+                        : [0, 0, 0, 0],
             y: (d) => d.tag[0],
-            symlogConstant: 5.5,
+            symlogConstant: 0.1,
             xTickFormat: (d) =>
-                d === 1
+                d === 5
                     ? "≤ 5"
                     : formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
-            xDomain: [1, 500000],
-            xTickValues: [1, 50, 500, 5000, 50000],
+            xDomain: [5, 500000],
+            xTickValues: [5, 50, 500, 5000, 50000],
             width: 600,
             height: 375,
             displayValue: true,

--- a/src/js/webcomponents/DamageGraph.js
+++ b/src/js/webcomponents/DamageGraph.js
@@ -55,16 +55,6 @@ class DamageGraph extends HTMLElement {
         this.node = this._root.querySelector('div:first-of-type').firstChild;
     }
 
-    getZeroTick = (lng) => {
-        let tick = {
-            de: 'keine',
-            fr: 'aucune',
-            it: 'nessuno',
-            en: 'none',
-        };
-        return tick[lng];
-    };
-
     updateGraph = () => {
         const graphNode = CantonalGraph(this.data, 2, {
             marginLeft: 30,
@@ -75,7 +65,7 @@ class DamageGraph extends HTMLElement {
             symlogConstant: 5.5,
             xTickFormat: (d) =>
                 d === 1
-                    ? this.getZeroTick(this.language)
+                    ? "≤ 5"
                     : formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
             xDomain: [1, 500000],
             xTickValues: [1, 50, 500, 5000, 50000],

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -63,7 +63,7 @@ class LossGraph extends HTMLElement {
             marginRight: 20,
             widthDamage: 0,
             gutter: 60,
-            x: (d) => [d.loss_pc10 < 1 ? 0 : d.loss_pc10,
+            x: (d) => [d.loss_pc10 < 1 && d.loss_mean < 1 ? 0 : d.loss_pc10,
                        d.loss_mean < 1 ? 0 : d.loss_mean,
                        d.loss_pc90 < 1 ? 0 : d.loss_pc90],
             y: (d) => d.tag,

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -63,7 +63,9 @@ class LossGraph extends HTMLElement {
             marginRight: 20,
             widthDamage: 0,
             gutter: 60,
-            x: (d) => [d.loss_pc10, d.loss_mean, d.loss_pc90],
+            x: (d) => [d.loss_pc10 < 1 ? 0 : d.loss_pc10,
+                       d.loss_mean < 1 ? 0 : d.loss_mean,
+                       d.loss_pc90 < 1 ? 0 : d.loss_pc90],
             y: (d) => d.tag,
             symlogConstant: 0.1,
             xTickFormat: (d) => d === 0.5 ? '0'

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -66,9 +66,10 @@ class LossGraph extends HTMLElement {
             x: (d) => [d.loss_pc10, d.loss_mean, d.loss_pc90],
             y: (d) => d.tag,
             symlogConstant: 0.1,
-            xTickFormat: (d) => formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
+            xTickFormat: (d) => d === 0.5 ? '0'
+             : formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
             xDomain: [0.5, 50000],
-            xTickValues: [0, 5, 50, 500, 5000],
+            xTickValues: [0.5, 5, 50, 500, 5000],
             width: 600,
             height: 375,
             displayValue: false,

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -56,17 +56,6 @@ class LossGraph extends HTMLElement {
         this.node = this._root.querySelector('div:first-of-type').firstChild;
     }
 
-    // get the text for the first tick in the correct language
-    getZeroTick = (lng) => {
-        let tick = {
-            de: 'keine',
-            fr: 'aucune',
-            it: 'nessuno',
-            en: 'none',
-        };
-        return tick[lng];
-    };
-
     // update the graph
     updateGraph = () => {
         const graphNode = CantonalGraph(this.data, 1, {
@@ -79,7 +68,7 @@ class LossGraph extends HTMLElement {
             symlogConstant: 0.1,
             xTickFormat: (d) =>
                 d === 0.5
-                    ? this.getZeroTick(this.language)
+                    ? 0
                     : formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
             xDomain: [0.5, 50000],
             xTickValues: [0.5, 5, 50, 500, 5000],

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -66,12 +66,9 @@ class LossGraph extends HTMLElement {
             x: (d) => [d.loss_pc10, d.loss_mean, d.loss_pc90],
             y: (d) => d.tag,
             symlogConstant: 0.1,
-            xTickFormat: (d) =>
-                d === 0.5
-                    ? 0
-                    : formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
+            xTickFormat: (d) => formatLocale({ thousands: "'", grouping: [3] }).format(',.0f')(d),
             xDomain: [0.5, 50000],
-            xTickValues: [0.5, 5, 50, 500, 5000],
+            xTickValues: [0, 5, 50, 500, 5000],
             width: 600,
             height: 375,
             displayValue: false,

--- a/src/js/webcomponents/LossGraph.js
+++ b/src/js/webcomponents/LossGraph.js
@@ -63,9 +63,9 @@ class LossGraph extends HTMLElement {
             marginRight: 20,
             widthDamage: 0,
             gutter: 60,
-            x: (d) => [d.loss_pc10 < 1 && d.loss_mean < 1 ? 0 : d.loss_pc10,
-                       d.loss_mean < 1 ? 0 : d.loss_mean,
-                       d.loss_pc90 < 1 ? 0 : d.loss_pc90],
+            x: (d) => [d.loss_pc10 < 1 && d.loss_mean < 1 ? 0.5 : d.loss_pc10,
+                       d.loss_mean < 1 ? 0.5 : d.loss_mean,
+                       d.loss_pc90 < 1 ? 0.5 : d.loss_pc90],
             y: (d) => d.tag,
             symlogConstant: 0.1,
             xTickFormat: (d) => d === 0.5 ? '0'

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -171,8 +171,7 @@ class LossScale extends HTMLElement {
                           <div class="loss__icons-description">
                               <div class="loss__legend">
                             ${this.getZeroTick(this.losscategory,
-                                    this.language,
-                                    this.data.loss_mean)}
+                                    this.language)}
                               </div>
                               ${this.thresholds
                                   .slice(1, 5)

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -171,7 +171,7 @@ class LossScale extends HTMLElement {
                                     this.data.loss_mean)}
                               </div>
                               ${this.thresholds
-                                  .slice(1,5)
+                                  .slice(1, 5)
                                   .map(
                                       (step) =>
                                           html`<div class="loss__legend">

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -111,8 +111,8 @@ class LossScale extends HTMLElement {
         this.colorscale = this._root.getElementById('colorscale');
         this.colorScaleContext = ColorScale(this.colorscale);
 
-        const minValue = Math.round(this.thresholds[0]);
-                               
+        const minValue = Math.ceil(this.thresholds[0]);
+        
         const lossMean = this.data.loss_mean < minValue ?
                          this.thresholds[0] : this.data.loss_mean;
 

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -60,10 +60,10 @@ class LossScale extends HTMLElement {
     };
 
     // get the text for the first tick in the correct language and depending on loss category
-    getZeroTick = (losscategory, lng) => {
+    getZeroTick = (losscategory, lng, value) => {
         const tick = {
-            fatalities: "0",
-            displaced: "≤ 5",
+            fatalities: value <= 1 ? Math.round(value) : '0',
+            displaced: `≤ 5`,
             structural: `≤ ${numberToString(1000000, lng)} CHF`
         };
         return tick[losscategory];
@@ -72,9 +72,9 @@ class LossScale extends HTMLElement {
     // set the thresholds for the color scale and labels
     setThresholds = () => {
         const thresh = {
-            fatalities: [0, 5, 50, 500, 5000, 50000],
-            displaced: [0, 50, 500, 5000, 50000, 500000],
-            structural: [0, 10000000, 100000000, 1000000000, 10000000000, 100000000000],
+            fatalities: [0.5, 5, 50, 500, 5000, 50000],
+            displaced: [5, 50, 500, 5000, 50000, 500000],
+            structural: [1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000],
         };
         this.thresholds = thresh[this.losscategory];
     };
@@ -94,12 +94,13 @@ class LossScale extends HTMLElement {
     // check whether a loss icon should be active
     setHighlightedIcon = (lossID) => {
         if (!this.thresholds || !this.losscategory) return '';
+        const lossMean = Math.max(this.data.loss_mean, this.thresholds[0]);  
         const isTrue =
-            (this.thresholds[lossID - 1] <= this.data.loss_mean &&
-                (this.thresholds[lossID] || this.data.loss_mean + 1) > this.data.loss_mean) ||
+            (this.thresholds[lossID - 1] <= lossMean &&
+                (this.thresholds[lossID] || lossMean + 1) > lossMean) ||
             (lossID === this.thresholds.length - 1 &&
-                this.data.loss_mean >= this.thresholds[this.thresholds.length - 1]);
-
+                lossMean >= this.thresholds[this.thresholds.length - 1]);
+    
         return isTrue ? `active-${this.losscategory}` : '';
     };
 
@@ -165,10 +166,12 @@ class LossScale extends HTMLElement {
                           </div>
                           <div class="loss__icons-description">
                               <div class="loss__legend">
-                                    ${this.getZeroTick(this.losscategory,this.language)}
+                            ${this.getZeroTick(this.losscategory,
+                                    this.language,
+                                    this.data.loss_mean)}
                               </div>
                               ${this.thresholds
-                                  .slice(1, 5)
+                                  .slice(1,5)
                                   .map(
                                       (step) =>
                                           html`<div class="loss__legend">

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -59,15 +59,14 @@ class LossScale extends HTMLElement {
         });
     };
 
-    // get the text for the first tick in the correct language
-    getZeroTick = (lng) => {
+    // get the text for the first tick in the correct language and depending on loss category
+    getZeroTick = (losscategory, lng) => {
         const tick = {
-            de: 'keine',
-            fr: 'aucune',
-            it: 'nessuno',
-            en: 'none',
+            fatalities: "0",
+            displaced: "≤ 5",
+            structural: `≤ ${numberToString(1000000, lng)} CHF`
         };
-        return tick[lng];
+        return tick[losscategory];
     };
 
     // set the thresholds for the color scale and labels
@@ -165,7 +164,9 @@ class LossScale extends HTMLElement {
                               </div>
                           </div>
                           <div class="loss__icons-description">
-                              <div class="loss__legend">${this.getZeroTick(this.language)}</div>
+                              <div class="loss__legend">
+                                    ${this.getZeroTick(this.losscategory,this.language)}
+                              </div>
                               ${this.thresholds
                                   .slice(1, 5)
                                   .map(

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -94,7 +94,8 @@ class LossScale extends HTMLElement {
     // check whether a loss icon should be active
     setHighlightedIcon = (lossID) => {
         if (!this.thresholds || !this.losscategory) return '';
-        const lossMean = Math.max(this.data.loss_mean, this.thresholds[0]);  
+        const lossMean = Math.max(this.data.loss_mean, this.thresholds[0]);
+
         const isTrue =
             (this.thresholds[lossID - 1] <= lossMean &&
                 (this.thresholds[lossID] || lossMean + 1) > lossMean) ||
@@ -110,15 +111,23 @@ class LossScale extends HTMLElement {
         this.colorscale = this._root.getElementById('colorscale');
         this.colorScaleContext = ColorScale(this.colorscale);
 
+        const minValue = Math.round(this.thresholds[0]);
+                               
+        const lossMean = this.data.loss_mean < minValue ?
+                         this.thresholds[0] : this.data.loss_mean;
+
+        const lossPc10 = this.data.loss_pc10 < minValue && 
+                         this.data.loss_mean < minValue ? 
+                         this.thresholds[0] : this.data.loss_pc10;
+
+        const lossPc90 = this.data.loss_pc90 < minValue ?
+                         this.thresholds[0] : this.data.loss_pc90;
+
         let [meanPct, p10Pct, p90Pct] = [
-            this.data.loss_mean,
-            this.data.loss_pc10,
-            this.data.loss_pc90,
-        ].map((v) => {
-            if (v < Math.round(this.thresholds[0])) return 0; 
-            return getPercentage(v, this.thresholds)
-        }
-        );
+            lossMean,
+            lossPc10,
+            lossPc90,
+        ].map((v) => getPercentage(v, this.thresholds));
 
         let rootStyleSelector = document.querySelector(':root').style;
 

--- a/src/js/webcomponents/LossScale.js
+++ b/src/js/webcomponents/LossScale.js
@@ -60,9 +60,9 @@ class LossScale extends HTMLElement {
     };
 
     // get the text for the first tick in the correct language and depending on loss category
-    getZeroTick = (losscategory, lng, value) => {
+    getZeroTick = (losscategory, lng) => {
         const tick = {
-            fatalities: value <= 1 ? Math.round(value) : '0',
+            fatalities: '0',
             displaced: `≤ 5`,
             structural: `≤ ${numberToString(1000000, lng)} CHF`
         };
@@ -114,7 +114,11 @@ class LossScale extends HTMLElement {
             this.data.loss_mean,
             this.data.loss_pc10,
             this.data.loss_pc90,
-        ].map((v) => getPercentage(v, this.thresholds));
+        ].map((v) => {
+            if (v < Math.round(this.thresholds[0])) return 0; 
+            return getPercentage(v, this.thresholds)
+        }
+        );
 
         let rootStyleSelector = document.querySelector(':root').style;
 

--- a/src/sass/loss_scale.wc.scss
+++ b/src/sass/loss_scale.wc.scss
@@ -78,8 +78,8 @@
         text-align: center;
         align-content: center;
 
-        &:last-of-type,
-        &:first-of-type {
+        &:first-of-type,
+        &:last-of-type {
             width: 10%;
         }
 

--- a/src/sass/loss_scale.wc.scss
+++ b/src/sass/loss_scale.wc.scss
@@ -77,14 +77,18 @@
         line-height: 1.2em;
         text-align: center;
 
-        &:first-of-type,
         &:last-of-type {
             width: 10%;
         }
 
+        &:first-of-type,
+        &:nth-child(2) {
+            width: 15%;
+        }
+
         &:first-of-type {
             position: relative;
-            left: -4%;
+            text-align: left;
         }
 
         &::after {

--- a/src/sass/loss_scale.wc.scss
+++ b/src/sass/loss_scale.wc.scss
@@ -76,19 +76,16 @@
         font-size: 1.2em;
         line-height: 1.2em;
         text-align: center;
+        align-content: center;
 
-        &:last-of-type {
+        &:last-of-type,
+        &:first-of-type {
             width: 10%;
-        }
-
-        &:first-of-type,
-        &:nth-child(2) {
-            width: 15%;
         }
 
         &:first-of-type {
             position: relative;
-            text-align: left;
+            left: -4%;
         }
 
         &::after {


### PR DESCRIPTION
#54 

### Reproject Value Ranges:
* Change the value range from [0.1, 10M] to [1M, 10M].
* Adjust the value range from [0, 50] to [5, 50].

### Update Minimum Value Thresholds:
* Modify the thresholds for the minimum value to reflect changes both in the labels and the colorscale.

### Adjust Damage Graph Parameters:
* Update the xDomain, xTickValues, and the symlog constant specifically for the damage graph.

~~Note: For the damage graphs, the reprojection of values in the range [5, 50] is based on the condition that d.damage_pc90 >= 5. Feel free to change it if you prefer `d.damage_mean` (or if you find any incorrect assumptions...).~~ Conditional filter for input data is not needed as the domain is constraint to [5, 500'000] 